### PR TITLE
Update cicd

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -36,16 +36,20 @@ jobs:
           distribution: "liberica"
           java-version: 17
 
+      #----------- Install SBT -----------
+      - name: Setup SBT
+        uses: sbt/setup-sbt@v1
+
       #----------- CACHE -----------
       - name: Cache SBT
-        uses: actions/cache@v4.1.0
+        uses: actions/cache@v4.2.3
         with:
           # A list of files, directories, and wildcard patterns to cache and restore
           path: |
             ~/.ivy2/cache
             ~/.sbt
           # An explicit key for restoring and saving the cache
-          key: ${{ runner.os }}-sbt-${{ matrix.scala }}-${{ hashFiles('**/build.sb') }}
+          key: ${{ runner.os }}-sbt-${{ matrix.scala }}-${{ hashFiles('**/build.sbt') }}
 
       #----------- COMPILE -----------
       - name: Compile, Format, Test and Coverage for ${{ matrix.scala }}
@@ -77,7 +81,7 @@ jobs:
 
       #----------- CACHE -----------
       - name: Cache SBT
-        uses: actions/cache@v4.1.0
+        uses: actions/cache@v4.2.3
         with:
           # A list of files, directories, and wildcard patterns to cache and restore
           path: |

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 import sbt.addSbtPlugin
 
 addSbtPlugin("org.scalameta"  % "sbt-scalafmt"    % "2.5.4")
-addSbtPlugin("org.scoverage"  % "sbt-scoverage"   % "2.2.2")
+addSbtPlugin("org.scoverage"  % "sbt-scoverage"   % "2.3.0")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release"  % "1.9.2")
 addSbtPlugin("org.scalameta"  % "sbt-mdoc"        % "2.6.4")
 addSbtPlugin("com.typesafe"   % "sbt-mima-plugin" % "1.1.4")


### PR DESCRIPTION
## Motivation
In projects that are using Fly4s we are receiving a warning about upgrading Flyway. Currently there are a handful of dependency updates that have failing PR builds. This PR should get those builds working again to allow the dependency updates. 

```
Flyway upgrade recommended: PostgreSQL 16.8 is newer than this version of Flyway and support has not been tested. The latest supported version of PostgreSQL is 15.
```

## Changes:

- Update `actions/cache` to the newest version as `4.1.0` was marked as deprecated [v4.2.0 release notes](https://github.com/actions/cache/releases/tag/v4.2.0)
- Install SBT, base images like ubuntu are removing sbt from the base image. Sbt now needs to be installed in the process. [Github thread for context](https://github.com/actions/setup-java/issues/627#issuecomment-2184234779)