### PR TITLE
Fix unhandled exception on Resource release

### DIFF
--- a/core/src/main/scala/fly4s/Fly4s.scala
+++ b/core/src/main/scala/fly4s/Fly4s.scala
@@ -296,7 +296,11 @@ object Fly4s extends AllInstances {
         F.blocking { flyway.repair() }
 
       override private[fly4s] def close: F[Unit] =
-        F.delay { flyway.getConfiguration.getDataSource.getConnection.close() }
+        flyway.getConfiguration.getDataSource match {
+          case ac: AutoCloseable => F.blocking(ac.close())
+          case _                 => F.unit
+        }
+
     }
 
   }

--- a/core/src/test/scala/fly4s/Fly4sTest.scala
+++ b/core/src/test/scala/fly4s/Fly4sTest.scala
@@ -205,18 +205,25 @@ class Fly4sTest extends munit.CatsEffectSuite {
     } yield ()
   }
 
-  test("close should not fail when the DB is not available (bug replication)") {
+  test("Resource release should not add a suppressed error") {
     val deadUrl = "jdbc:h2:tcp://localhost:1/closedb"
 
     Fly4s
       .make[IO](deadUrl)
-      .use(_.migrate.attempt)
+      .use(_.migrate)
       .attempt
       .map { result =>
+        assert(result.isLeft, s"migrate should fail with the database down: $result")
+
+        val err = result.left.get
+        val closeSuppressed =
+          err.getSuppressed.exists(_.getStackTrace.exists(_.getClassName.startsWith("fly4s.Fly4s")))
+
         assert(
-          result.isRight,
-          s"program should succeed because `use` handled the migration error, but it failed: $result"
+          !closeSuppressed,
+          s"release must not add a suppressed error originating from fly4s.Fly4s: ${err.getSuppressed.mkString(", ")}"
         )
       }
   }
 }
+

--- a/core/src/test/scala/fly4s/Fly4sTest.scala
+++ b/core/src/test/scala/fly4s/Fly4sTest.scala
@@ -204,4 +204,19 @@ class Fly4sTest extends munit.CatsEffectSuite {
       )
     } yield ()
   }
+
+  test("close should not fail when the DB is not available (bug replication)") {
+    val deadUrl = "jdbc:h2:tcp://localhost:1/closedb"
+
+    Fly4s
+      .make[IO](deadUrl)
+      .use(_.migrate.attempt)
+      .attempt
+      .map { result =>
+        assert(
+          result.isRight,
+          s"program should succeed because `use` handled the migration error, but it failed: $result"
+        )
+      }
+  }
 }


### PR DESCRIPTION
## Problem
I had a problem when I started my app and the DB was not running. Using `Fly4s` as a `Resource` and letting `use` handle its own migration error caused an unhandled exception that crashed the application (surfaced through cats-effect's `reportFailure`).

## Root cause
`Fly4s.close` called `getConnection()` on the configured `DataSource`. This opens a *new* connection and therefore requires the database to be reachable. When the database was down, `close` threw `JdbcSQLNonTransientConnectionException: Connection refused`. Because `use` had already succeeded, cats-effect 3 promotes a release error to the primary failure of the whole `use` block, which then escaped as an unhandled exception in an `IOApp`.

## Fix
`javax.sql.DataSource` is not `AutoCloseable`, and Flyway's `DriverDataSource` (the default `make` path) is not either. Flyway already closes the per-operation connections it opens, so there is nothing for `close` to release in that case. The fix only releases the `DataSource` when it actually is `AutoCloseable`, otherwise `close` is a no-op and never touches the database.

Any error from a real pool's `close()` is still raised inside `F`, so it remains in the effect and is not silently swallowed.

## Test
Added a regression test that builds a `Fly4s` resource against a dead database, lets `use` handle its migration error, and asserts the program still succeeds.